### PR TITLE
Add design philosophy and roadmap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # BetAnalytics
+
+BetAnalytics is an in-development Python package for building automated, coherent NBA betting insights focused on spread, total, and moneyline markets. The platform will combine five years of historical game and odds data with unified game simulations to deliver consistent predictions, mobile alerts, and optional social media syndication powered by AI-generated narratives.
+
+## Current Status
+- ✅ Repository scaffolding with a documented [design philosophy](docs/design_philosophy.md) that outlines architecture, tooling, and roadmap expectations.
+- 🚧 Implementation of data ingestion, modelling, automation, and delivery components is forthcoming.
+
+## Design Highlights
+- **Unified Predictions** – Maintain a single probabilistic game view from which spread, total, and moneyline edges are derived.
+- **Automated Data Pipelines** – Collect, validate, and version at least five seasons of NBA and betting market data.
+- **End-to-End Automation** – Schedule ingestion, training, and inference workflows that can notify mobile users and optionally post top picks to social channels.
+- **Extensibility** – Modular package layout designed to support future prop bet modelling and additional distribution channels.
+- **Governed MLOps** – Built-in coherence checks, model registry expectations, and responsible gaming guardrails sustain trust in automated delivery.
+
+Refer to the [design philosophy](docs/design_philosophy.md) for detailed guidance on architecture, tooling choices, automation practices, and roadmap milestones. Keep this README synchronized with the codebase as implementation progresses.
+
+## Next Steps
+1. Establish project tooling (`pyproject.toml`, linting, testing, CI) following the documented best practices.
+2. Implement data collectors for NBA statistics and betting odds with backfilling support.
+3. Build unified modelling pipelines, implement coherence enforcement tests, and register artefacts with a governed model registry.
+4. Add delivery mechanisms (CLI/API, notification services, social posting) with monitoring, incident runbooks, and responsible gaming messaging.
+5. Iterate on documentation (README, design philosophy, runbooks) to reflect new capabilities, ensuring coherence between README and implementation.
+
+## Contributing
+Until the package is feature-complete, contributions should focus on aligning new code with the documented design principles and maintaining high-quality, well-tested code. Update both this README and the design philosophy document whenever architectural decisions evolve.
+

--- a/docs/design_philosophy.md
+++ b/docs/design_philosophy.md
@@ -1,0 +1,138 @@
+# BetAnalytics Design Philosophy
+
+## Vision
+BetAnalytics aims to be a reliable, automated NBA wagering intelligence platform that delivers coherent spread, total, and moneyline predictions informed by unified game simulations. The system should surface actionable insights to end-users on mobile devices and optionally syndicate top recommendations to social media via AI-generated narratives.
+
+## Guiding Principles
+1. **Holistic Game Representation** – Model every game through a shared probabilistic view (e.g., joint score distributions) to ensure internal consistency between spread, total, and moneyline outputs while remaining extensible to future prop markets.
+2. **Data Integrity First** – Automate data acquisition with strong validation, deduplication, and versioning to guarantee five years of trustworthy historical NBA and betting datasets.
+3. **Automation with Control** – Design pipelines that run on schedules or events with robust monitoring, logging, and manual override capabilities.
+4. **Modularity & Extensibility** – Implement clearly bounded modules (data, features, models, delivery) to simplify iteration, testing, and future enhancements.
+5. **Reproducibility & Transparency** – Ensure every prediction is traceable to data versions, model artifacts, and configuration; expose explanatory summaries alongside recommendations.
+6. **Secure & Compliant Operations** – Protect API credentials, respect data terms-of-service, and audit outgoing communications, especially for social media automation.
+
+## Architectural Overview
+
+### High-Level Components
+- **Data Acquisition Layer**: Connectors to NBA statistics (e.g., NBA Stats API, Sportradar, data.nba.com) and betting odds providers (e.g., OddsJam, TheOddsAPI, sportsbook scraping) covering at least the past five seasons. Incorporate caching, retry logic, and rate-limit awareness.
+- **Data Lake & Warehouse**: Raw data stored in an immutable data lake (parquet/Delta) with curated tables for modelling. Track schema versions with migrations managed by tools like Alembic or DuckDB macros.
+- **Feature Engineering**: Create derived features such as pace, offensive/defensive efficiencies, rest days, travel distance, injury reports, and betting market moves. Apply consistent scaling/encoding pipelines saved with the model artifacts.
+- **Modelling & Simulation**: Generate unified game-level probabilistic outputs (e.g., Bayesian hierarchical models, Elo-style ratings with tempo adjustments, or deep learning sequence models). Simulate possessions/scorelines to derive spread, total, and moneyline probabilities simultaneously.
+- **Evaluation & Monitoring**: Backtest using walk-forward validation over the five-year dataset. Track profitability metrics (ROI, CLV), calibration (Brier score, log loss), and coverage of implied probabilities.
+- **Delivery & Automation**: Schedule daily jobs to ingest new data, retrain/refresh models, compute predictions, and push notifications. Provide CLI/API endpoints for manual execution.
+- **Notification & Social Modules**: Integrate with mobile push/email/SMS services (e.g., Firebase, Twilio) and social APIs (X, Instagram Threads). Use LLMs to craft human-readable posts while enforcing compliance filters.
+
+### Package Layout (Proposed)
+```
+bet_analytics/
+    __init__.py
+    config/
+        __init__.py
+        settings.py
+    data/
+        collectors/
+        validators.py
+        transforms.py
+    features/
+        __init__.py
+        pipelines.py
+    models/
+        __init__.py
+        scoring.py
+        evaluation.py
+    pipelines/
+        __init__.py
+        training.py
+        inference.py
+    delivery/
+        notifications.py
+        social.py
+    interfaces/
+        cli.py
+        api.py
+
+config/
+    default.toml
+
+scripts/
+    backfill_data.py
+    run_predictions.py
+
+tests/
+    unit/
+    integration/
+```
+
+- **Configuration Management**: Centralize runtime configuration using typed settings (e.g., `pydantic-settings`). Support environment profiles (dev, staging, prod).
+- **Dependency Management**: Use a modern tool like Poetry or PDM. Enforce semantic versioning and maintain a changelog.
+- **Testing & Quality**: Adopt `pytest`, `mypy`, `ruff`, and `black`. Enforce CI (GitHub Actions) with automated tests, type checking, linting, and documentation builds.
+
+## Data Strategy
+- **Historical Coverage**: Build backfill jobs to retrieve five seasons of NBA game logs, team/player stats, injuries, and odds (opening & closing lines). Use incremental loads for daily updates.
+- **Source Evaluation**: Prioritize official or licensed APIs (NBA Stats, Sportradar) with documented latency and quality SLAs; maintain vetted fallback scrapers for redundancy and document ToS compliance.
+- **Data Contracts**: Define schemas for each dataset with strict typing; use Pydantic models for runtime validation.
+- **Storage**: Store raw JSON/CSV dumps, normalized relational tables, and aggregated analytical tables. Prefer columnar formats (Parquet) for analytics.
+- **Versioning**: Track dataset versions and provenance metadata (source endpoint, pull timestamp). Consider tools like DVC or LakeFS for dataset version control.
+- **Quality Checks**: Implement data completeness checks (e.g., verifying all scheduled games), anomaly detection (odds outliers), and alignment checks between stats and odds tables.
+- **Access Management**: Rotate API keys regularly, limit secret scope per environment, and instrument request logs for auditing and throttling diagnostics.
+
+## Modelling Philosophy
+- **Unified Game Simulation**: Fit models that produce expected team scores distribution (e.g., bivariate Poisson, neural nets with Monte Carlo dropout). Derive spread, total, and moneyline from the same simulated score outcomes to maintain coherence.
+- **Feature Consistency**: Ensure features used for spread, total, and moneyline predictions stem from the same feature pipeline. Avoid ad-hoc feature sets per bet type unless justified and validated.
+- **Probabilistic Outputs**: Calibrate predictions to produce implied probabilities; convert to American odds and compare with market lines for edge estimation.
+- **Explainability**: Provide feature attribution (e.g., SHAP values) for transparency and compliance with social media policies.
+- **Model Lifecycle**: Support periodic retraining, champion/challenger comparisons, and rollback mechanisms.
+
+### Coherence Enforcement Playbook
+- **Shared Simulation Contract**: Define a score-distribution interface (expected score vector, covariance, simulation sampler) that all market modules consume, preventing drift between moneyline, spread, and total projections.
+- **Consistent Odds Translation**: Centralize the logic that converts simulation outputs into implied probabilities, prices, and American odds. Apply rounding rules once to ensure marketing copy, app displays, and social posts stay consistent.
+- **Cross-Market Validation**: Add automated tests that verify internal consistency (e.g., moneyline-derived implied spread vs. published spread edge) and flag violations before delivery.
+- **Calibration Reviews**: Schedule quarterly calibration audits comparing predicted distributions against realized outcomes; feed adjustments back into simulation priors and feature engineering.
+
+### Model Governance & Risk Management
+- **Model Registry**: Track every trained artefact with metadata (data range, feature versions, hyperparameters, evaluation metrics) using MLflow or Weights & Biases.
+- **Approval Workflow**: Require human approval for promoting models to production and provide rollback hooks that can redeploy the previous champion in minutes.
+- **Performance Guardrails**: Define automatic disable rules when backtests or live performance fall below thresholds (ROI, Brier score, CLV). Notifications should include recommended mitigation steps.
+- **Responsible Gaming Signals**: Incorporate limits around stake sizing recommendations and provide configurable stop-loss logic when performance degrades.
+
+## Automation & Delivery
+- **Scheduling**: Use `APScheduler`, Prefect, or Airflow for orchestrating ingestion, training, and inference workflows. Support manual triggers through CLI/API.
+- **Notification Pipeline**: Summarize top edges and push to user devices using secure tokens. Allow user-configurable thresholds and frequency.
+- **Social Media Automation**: Gate autoposting behind confidence thresholds and compliance checks. Use templated prompts to generate posts via LLMs; include human-in-the-loop override for sensitive markets.
+- **Monitoring**: Log every job with structured logging (e.g., `structlog`) and metrics (Prometheus/Grafana). Alert on failures or degraded model performance.
+
+### Operational Runbook
+- **Environment Promotion**: Mirror workflows across dev, staging, and production with isolated credentials. Require successful dry runs in staging before promoting schedules.
+- **Data Freshness SLAs**: Track ingestion latency against NBA schedule milestones (e.g., morning injury reports, pre-tip odds). Trigger alerts when data falls behind the defined SLA window.
+- **Disaster Recovery**: Maintain daily backups of the warehouse and model registry. Document restoration steps and practice them quarterly.
+- **Mobile & API Contracts**: Version notification payloads and API schemas, and provide compatibility tests to prevent breaking consumer apps during deployments.
+
+### Notification & Social Content Guidelines
+- **Message Structure**: Standardize copy templates that include matchup, bet type, model edge, and confidence along with the responsible gaming disclaimer.
+- **Attribution Metadata**: Embed model version, data cut timestamp, and confidence interval in hidden fields or analytics tags for later auditing.
+- **Escalation Rules**: Require human sign-off for bets that exceed predefined edge or stake thresholds, or when novel market types are detected.
+- **Localization & Accessibility**: Support multiple locales/time zones and ensure copy adheres to accessibility guidelines (e.g., emoji limits, screen-reader friendly formatting).
+
+## Documentation & Collaboration
+- Maintain this design philosophy alongside architectural diagrams (Mermaid/PlantUML) and update with any major structural change.
+- Document API usage, module responsibilities, and developer onboarding steps in the README and supplementary docs.
+- Provide example notebooks illustrating data exploration and modelling workflows.
+- Record postmortems for incidents, linking remediation tasks to backlog tickets.
+
+## Security, Compliance & Responsible Gaming
+- Secure environment variables and API keys using secrets management (e.g., AWS Secrets Manager, HashiCorp Vault).
+- Respect licensing/ToS for data providers and social networks.
+- Implement rate limiting and request backoff strategies to avoid bans.
+- Provide disclaimers within user-facing channels reminding bettors to gamble responsibly and comply with jurisdictional regulations.
+- Log outbound social posts and mobile notifications for auditing, including the model version and decision rationale.
+
+## Roadmap Highlights
+1. **MVP** – Build data ingestion & validation, baseline joint game model, CLI notifications.
+2. **Automation Layer** – Introduce scheduling, monitoring, and automated mobile delivery.
+3. **Social Media AI** – Add AI-generated summaries with guardrails.
+4. **Prop Expansion** – Extend unified game model to player prop projections.
+5. **Continuous Improvement** – Deploy CI/CD, experiment tracking, and automated documentation pipelines.
+
+## README Alignment
+- The repository README should summarize the current implementation status, reference this design philosophy, and list active components. Update both when architecture or scope changes.
+


### PR DESCRIPTION
## Summary
- document the guiding principles and architecture for the BetAnalytics NBA betting platform
- outline package structure, data strategy, modelling philosophy, automation plans, and roadmap in a new design philosophy document, now including coherence enforcement, governance, and responsible gaming guidance
- update the README to reflect the project vision, current status, governance expectations, and next implementation steps aligned with the design

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cc0722a2fc832c9a61c8642ea7a4fb