### PR TITLE
Add lxml dependency for BeautifulSoup parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pandas>=2.2.0",
     "requests>=2.32.0",
     "beautifulsoup4>=4.12.0",
+    "lxml>=4.9.0",
     "pyarrow>=15.0.0"
 ]
 


### PR DESCRIPTION
## Summary
- add lxml as a required dependency so BeautifulSoup has an HTML parser available

## Testing
- pip install -e .
- python scripts/collect_basketball_reference_data.py *(fails: HTTPSConnectionPool via proxy 403 while fetching data)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4c5d35b8832c8507e9d6225d4546